### PR TITLE
Adding more detailed Ansible and Terraform configurations

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -24,6 +24,14 @@ jobs:
         run: terraform init
         working-directory: ./terraform
 
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: ./terraform
+
+      - name: Terraform Format
+        run: terraform fmt -check
+        working-directory: ./terraform
+
       - name: Terraform Apply
         run: terraform apply -auto-approve
         working-directory: ./terraform
@@ -32,6 +40,9 @@ jobs:
         uses: dawidd6/action-ansible-playbook@v2
         with:
           playbook: ./ansible/playbook.yml
+
+      - name: Run Ansible Lint
+        run: ansible-lint ./ansible/playbook.yml
 
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@
      ```sh
      terraform init
      ```
+   - Validate the Terraform configuration:
+     ```sh
+     terraform validate
+     ```
+   - Format the Terraform configuration:
+     ```sh
+     terraform fmt
+     ```
    - Apply the Terraform configuration:
      ```sh
      terraform apply
@@ -41,6 +49,10 @@
    - Run the Ansible playbook:
      ```sh
      ansible-playbook playbook.yml
+     ```
+   - Run Ansible lint checks:
+     ```sh
+     ansible-lint playbook.yml
      ```
 
 4. **Run Automated Tests:**
@@ -64,5 +76,16 @@
 
 2. **Automated Testing Stage:**
    - Runs unit tests and integration tests to ensure code quality.
+
+#### Configuring Firewall Rules, Monitoring, and SSL Certificates
+
+1. **Firewall Rules:**
+   - The Ansible playbook includes tasks to configure firewall rules using `ufw` to allow traffic on ports 80 and 443.
+
+2. **Monitoring:**
+   - The Ansible playbook includes tasks to set up monitoring using `prometheus` and `grafana`.
+
+3. **SSL Certificates:**
+   - The Ansible playbook includes tasks to configure SSL certificates using `certbot` to obtain and install certificates for your domain.
 
 For more detailed information, refer to the respective directories and their documentation.

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -37,3 +37,27 @@
       command: python3 manage.py collectstatic --noinput
       args:
         chdir: /path/to/application/code
+
+    - name: Configure firewall rules
+      ufw:
+        rule: allow
+        port: '80,443'
+        proto: tcp
+
+    - name: Set up monitoring with Prometheus
+      apt:
+        name: prometheus
+        state: present
+
+    - name: Set up monitoring with Grafana
+      apt:
+        name: grafana
+        state: present
+
+    - name: Configure SSL certificates
+      apt:
+        name: certbot
+        state: present
+
+    - name: Obtain SSL certificate
+      command: certbot --nginx -d yourdomain.com

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,12 +2,87 @@ provider "aws" {
   region = var.aws_region
 }
 
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "main-vpc"
+  }
+}
+
+resource "aws_subnet" "subnet_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-west-2a"
+
+  tags = {
+    Name = "subnet-a"
+  }
+}
+
+resource "aws_subnet" "subnet_b" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-west-2b"
+
+  tags = {
+    Name = "subnet-b"
+  }
+}
+
+resource "aws_security_group" "allow_tls" {
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
+}
+
 resource "aws_instance" "example" {
   ami           = var.ami_id
   instance_type = var.instance_type
+  subnet_id     = aws_subnet.subnet_a.id
+  vpc_security_group_ids = [aws_security_group.allow_tls.id]
 
   tags = {
     Name = "ExampleInstance"
+  }
+}
+
+resource "aws_db_instance" "default" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "bar"
+  parameter_group_name = "default.mysql5.7"
+  skip_final_snapshot  = true
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
   }
 }
 


### PR DESCRIPTION
Enhance the CI/CD pipeline with more detailed Ansible and Terraform configurations.

* **Ansible Configuration:**
  - Add tasks to configure firewall rules using `ufw` to allow traffic on ports 80 and 443.
  - Add tasks to set up monitoring using `prometheus` and `grafana`.
  - Add tasks to configure SSL certificates using `certbot` to obtain and install certificates for the domain.

* **Terraform Configuration:**
  - Add configuration for VPC and subnets.
  - Add configuration for security groups to allow TLS traffic.
  - Add additional AWS resources like RDS and S3.

* **CI Pipeline:**
  - Add steps to validate Terraform code using `terraform validate`.
  - Add steps to format Terraform code using `terraform fmt`.
  - Add steps to run Ansible lint checks using `ansible-lint`.

* **Documentation:**
  - Update CI/CD pipeline setup instructions to include new Terraform and Ansible steps.
  - Add section on configuring firewall rules, monitoring, and SSL certificates.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/spherus?shareId=85a700ab-6b4f-460a-b66e-ae7875329d7b).